### PR TITLE
Tweak code quality workflow

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -2,7 +2,10 @@ name: Code quality
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   quality:


### PR DESCRIPTION
We shouldn't run on pushes to any branch, just main. Plus, workflow dispatch allows us to trigger the workflow manually.